### PR TITLE
STITCH-430: Fix javascript examples

### DIFF
--- a/HTTP-service/HTTP-service-javascript/app.js
+++ b/HTTP-service/HTTP-service-javascript/app.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // allow anonymous user access for this app
     function doAnonymousAuth() {
-      stitchClient.authManager.anonymousAuth()
+      stitchClient.login()
         .then( result => {
           console.log("authenticated");
         }).catch( err => {

--- a/HTTP-service/HTTP-service-javascript/index.html
+++ b/HTTP-service/HTTP-service-javascript/index.html
@@ -3,7 +3,7 @@
        <head>
            <title>SendGrid API emailer</title>
            <meta charset="utf-8">
-           <script src="https://raw.githubusercontent.com/mongodb/stitch-js-sdk/230f75f8660c3337e81f53867c7c6014d2a3e10c/dist/web/stitch.min.js"></script>
+           <script src="https://cdn.rawgit.com/mongodb/stitch-js-sdk/230f75f8660c3337e81f53867c7c6014d2a3e10c/dist/web/stitch.min.js"></script>
            <script defer type="text/javascript" src="app.js"></script>
            <style>
                body { 

--- a/MongoRestaurant/MongoRestaurant-javascript/app.js
+++ b/MongoRestaurant/MongoRestaurant-javascript/app.js
@@ -4,8 +4,8 @@ document.addEventListener('DOMContentLoaded',() => {
     
     // Replace the STITCH-APP-ID with your Stitch Application ID
     // Replace the MONGODB-SERVICE-NAME with the name of the Stitch MongoDB Service
-    const stitchClient = new stitch.StitchClient("rest1-vvoul");
-    const mongoClient = stitchClient.service("mongodb", "mongodb1");
+    const stitchClient = new stitch.StitchClient("STITCH-APP-ID");
+    const mongoClient = stitchClient.service("mongodb", "mongodb-atlas");
     
     const db = mongoClient.db("guidebook");
     const coll = db.collection("restaurants");
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded',() => {
     var restaurantName = ""
     
     function doAnonymousAuth(){
-        stitchClient.authManager.anonymousAuth().then( result => {
+        stitchClient.login().then( result => {
             console.log("authenticated");
             
         }).catch( err => {

--- a/MongoRestaurant/MongoRestaurant-javascript/index.html
+++ b/MongoRestaurant/MongoRestaurant-javascript/index.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
     </head>
     <body>
-        <script src="https://raw.githubusercontent.com/mongodb/stitch-js-sdk/230f75f8660c3337e81f53867c7c6014d2a3e10c/dist/web/stitch.min.js"></script>
+        <script src="https://cdn.rawgit.com/mongodb/stitch-js-sdk/230f75f8660c3337e81f53867c7c6014d2a3e10c/dist/web/stitch.min.js"></script>
         <script defer type="text/javascript" src="app.js"></script>
         <div> 
             <input id="restaurantName" type="text" > </input>

--- a/helloworld/simple-example/index.html
+++ b/helloworld/simple-example/index.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://raw.githubusercontent.com/mongodb/stitch-js-sdk/230f75f8660c3337e81f53867c7c6014d2a3e10c/dist/web/stitch.min.js" type="text/javascript"></script>
+    <script src="https://cdn.rawgit.com/mongodb/stitch-js-sdk/230f75f8660c3337e81f53867c7c6014d2a3e10c/dist/web/stitch.min.js" type="text/javascript"></script>
     <script src="https://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
   </head>
   <body>
@@ -22,12 +22,12 @@
   <script type="text/javascript">
     // Set these values to match the ID of the app you created in the Stitch admin site (Clients page) and
     // the DB of the default rule created in the mongodb1 service (Rules tab).
-    var MY_APP_ID = "helloworld-fgyjb";
-    var MY_DB = "app-fgyjb";
+    var MY_APP_ID = "STITCH-APP-ID";
+    var MY_DB = "STITCH-DB-NAME";
 
     var stitchClient = new stitch.StitchClient(MY_APP_ID);
     function setupPage() {
-      var userInfo = stitchClient.auth();
+      var userInfo = stitchClient.login();
 
       if(userInfo){
         $(".login-link").hide()
@@ -36,10 +36,10 @@
             setupPage();
           });
         });
-        var userName = (userInfo.user.data && userInfo.user.data.name)  ? userInfo.user.data.name : "(unknown)";
-        $("#greeting").text("Hello " + userName + ",  you are logged in!");
+        
+        $("#greeting").text("Hello,  you are logged in anonymously!");
 
-        var db = stitchClient.service("mongodb", "mongodb1").db(MY_DB);
+        var db = stitchClient.service("mongodb", "mongodb-atlas").db(MY_DB);
 
         db.collection("items").find({owner_id: stitchClient.authedId()}, {})
           .then(function(data){


### PR DESCRIPTION
Summary:

raw.githubusercontent.com sends an incorrect MIME type, causing errors for certain javascript examples. This does not appear to affect the react examples. 

Some methods (namely logging in anon) were fixed.

The simple-example/helloworld is a little wonky, but we aren't including that on the stitch docs site either - it might need some TLC at some point. 