### PR TITLE
Return placeholder text to Stitch-Info.plist file

### DIFF
--- a/todo/ios/MongoDBSample/Resources/Stitch-Info.plist
+++ b/todo/ios/MongoDBSample/Resources/Stitch-Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>APP_ID</key>
-	<string>test-app-amjob</string>
+	<string><Your-App-ID></string>
 </dict>
 </plist>


### PR DESCRIPTION
the tutorial says:

"1. Open the MongoDBSample/Resources/Stitch-Info.plist file.
2. Update the APP_ID with your MongoDB Stitch app id and save.
In the MongoDB Stitch console, you can find your App ID in the Clients view."

And there is code in the view controller to error out if that step isn't followed, but this version of the file contains an actual App ID, not the placeholder text.