### PR TITLE
Fixing Uncaught SyntaxError

### DIFF
--- a/basic-blog/blog.html
+++ b/basic-blog/blog.html
@@ -17,7 +17,7 @@
           .find({}, { limit: 1000 })
           .asArray()
           .then(docs => {
-            const html = docs.map(doc => `<div>${doc.comment}</div>`));
+            const html = docs.map(doc => `<div>${doc.comment}</div>`);
             document.getElementById("comments").innerHTML = html;
           })
       }


### PR DESCRIPTION
Uncaught SyntaxError: Unexpected token ) on line 20. 

This error was causing the HTML to not load correctly. Fixing should make it easy for a new user to get a working blog tutorial up and running.