### PR TITLE
Fixed various errors in the no_hardware app of the IoT Temperature Tracking example

### DIFF
--- a/IoTTemperatureTracking/no_hardware.js
+++ b/IoTTemperatureTracking/no_hardware.js
@@ -1,5 +1,5 @@
 // Set-up the Stitch client
-import Stitch from 'mongodb-stitch-browser-sdk';
+const stitch = require('mongodb-stitch-server-sdk');
 
 // Send sample data while within this loop
 function generateData(stitchClient) {
@@ -14,15 +14,15 @@ function generateData(stitchClient) {
    console.log(data);
 
    // Simulate write to MongoDB every 2 minutes
-   stitchClient.callFunction("Imp_Write", data).then(
+   stitchClient.callFunction("logTemperatureReading", [data]).then(
       setTimeout(() => generateData(stitchClient), 120000)
    );
 }
 
 // Use the API Key to load data
-const stitchClient = Stitch.initializeDefaultAppClient("<your-app-id>");
+const stitchClient = stitch.Stitch.initializeDefaultAppClient("<your-app-id>");
 
-stitchClient.auth.loginWithCredential(new ServerApiKeyCredential("<STITCH API KEY>"))
+stitchClient.auth.loginWithCredential(new stitch.ServerApiKeyCredential("<STITCH API KEY>"))
    .then(() => {
       generateData(stitchClient);
 });

--- a/IoTTemperatureTracking/package.json
+++ b/IoTTemperatureTracking/package.json
@@ -9,6 +9,6 @@
   "author": "Drew DiPalma",
   "license": "MIT",
   "dependencies": {
-    "mongodb-stitch": "^3.0.0"
+    "mongodb-stitch-server-sdk": "^4.0.0"
   }
 }


### PR DESCRIPTION
There are various errors in the no_hardware.js app of the IoTTemperatureTracking example. When running as is it throws an error, and after fixing one error it throws another, etc. It seems that the code is outdated and no longer in line with the documentation: https://docs.mongodb.com/stitch/tutorials/temperature-tracker/

I fixed the following:
- Use require instead of import as import doesn't work in Node 6 without using additional libraries such as Babel.
- Fixed the name of the Stitch function to be the same as the name used in the documentation: logTemperatureReading.
- Switched SDK from browser SDK to server SDK as browser SDK gives errors when running server-side (window undefined). Updated package.json to reflect this.