### PR TITLE
Unsmartened Smart Quotes in Podfile to stop warning

### DIFF
--- a/todo/ios/Podfile
+++ b/todo/ios/Podfile
@@ -1,6 +1,6 @@
 # Uncomment the next line to define a global platform for your project
 # See: https://guides.cocoapods.org/syntax/podfile.html#platform
-platform :ios, ‘11.0’
+platform :ios, '11.0'
 
 target 'ToDoSync' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks


### PR DESCRIPTION
Tidy up to stop warning...

```
[!] Smart quotes were detected and ignored in your Podfile. To avoid issues in the future, you should not use TextEdit for editing it. If you are not using TextEdit, you should turn off smart quotes in your editor of choice.
```

No longer appears with `pod install`